### PR TITLE
Single btn instead of two multiple buttons

### DIFF
--- a/components/signup/Form.jsx
+++ b/components/signup/Form.jsx
@@ -28,7 +28,6 @@ export default function Form() {
       addr: event.target.addr.value,
       city: event.target.city.value,
       zip: event.target.zip.value,
-      accountType: event.nativeEvent.submitter.name,
     };
     console.log(data)
   };
@@ -122,20 +121,12 @@ export default function Form() {
         </div>
       </div>
 
-      <div className="flex flex-col gap-4 mt-6 mb-2 md:gap-5 text-white font-medium">
+      <div className="flex flex-col mt-6 mb-2 text-white font-medium">
         <button
-          type='submit' id='buyer' name='buyer'
+          type='submit' id='submit'
           className="bg-gradient-to-r from-brand-red to-brand-purple rounded-md py-2.5 text-sm lg:text-base"
         >
-          Signup as Buyer
-        </button>
-        <button 
-            type='submit' id='seller' name='seller'
-            className="rounded-md bg-gradient-to-r from-brand-red to-brand-purple"
-        >
-          <div className="rounded-md py-2.5 bg-[#252525] m-[1px] text-sm lg:text-base">
-            Signup as Seller
-          </div>
+          Signup
         </button>
       </div>
     </form>


### PR DESCRIPTION
This commit is for making a single account for both buyer and seller. The only place where the "not to go ahead" feature existed is now removed. The signup page now looks as below:
<img width="1440" alt="single-bth" src="https://user-images.githubusercontent.com/34000860/189908005-1601b3cb-64cf-4000-a0a1-3a6fe344317e.png">
